### PR TITLE
zephyr: update include paths to use <zephyr/...>

### DIFF
--- a/kernelports/Zephyr/include/tracing_tracerecorder.h
+++ b/kernelports/Zephyr/include/tracing_tracerecorder.h
@@ -9,8 +9,8 @@
 #ifndef _TRACE_TRACERECORDER_H
 #define _TRACE_TRACERECORDER_H
 
-#include <kernel.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
 #include <trcRecorder.h>
 
 

--- a/kernelports/Zephyr/include/trcKernelPort.h
+++ b/kernelports/Zephyr/include/trcKernelPort.h
@@ -11,7 +11,7 @@
 #ifndef TRC_KERNEL_PORT_H
 #define TRC_KERNEL_PORT_H
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <version.h>
 #include <trcRecorder.h>
 

--- a/kernelports/Zephyr/trcKernelPort.c
+++ b/kernelports/Zephyr/trcKernelPort.c
@@ -8,8 +8,8 @@
  * The Zephyr specific parts of the trace recorder
  */
 
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <string.h>
 #include <trcRecorder.h>
 


### PR DESCRIPTION
Zephyr has prefixed all of its includes with <zephyr/...>. While the old
mode can still be used (CONFIG_LEGACY_INCLUDE_PATH) and is still enabled
by default, it's better to be prepared for its removal in the future.