### PR TITLE
Fix "unused variable" compiler warning

### DIFF
--- a/trcISR.c
+++ b/trcISR.c
@@ -151,6 +151,7 @@ traceResult xTraceISRBegin(TraceISRHandle_t xISRHandle)
 traceResult xTraceISREnd(TraceBaseType_t xIsTaskSwitchRequired)
 {
 	TraceISRCoreData_t* pxCoreData;
+	(void)xIsTaskSwitchRequired;
 	TRACE_ALLOC_CRITICAL_SECTION();
 
 	/* This should never fail */


### PR DESCRIPTION
When TRC_CFG_INCLUDE_ISR_TRACING is set to 0 xIsTaskSwitchRequired in xTraceISREnd() is not used.