### PR TITLE
Fix stack smashing

### DIFF
--- a/trcSnapshotRecorder.c
+++ b/trcSnapshotRecorder.c
@@ -3269,7 +3269,7 @@ void prvReportStackUsage(void)
 		if (tasksInStackMonitor[i].tcb != 0)
 		{
 			/* Get the amount of unused stack */
-			uint32_t unusedStackSpace;
+			TraceUnsignedBaseType_t unusedStackSpace;
 			xTraceKernelPortGetUnusedStack(tasksInStackMonitor[i].tcb, &unusedStackSpace);
 
 			/* Store for later use */


### PR DESCRIPTION

The function `prvReportStackUsage` passed a local stack variable of type uint32_t as output parameter to `xTraceKernelPortGetUnusedStack` which expected `uint64_t` on a 64-bit platform. This resulted in 4 byte memory corruption.

The problem was that `xTraceKernelPortGetUnusedStack` used `TraceUnsignedBaseType_t` type for the output parameter which got defined to `uint32_t` on a 32-bit platform and to `uint64_t` on a 64-bit platform, while the local stack variable in prvReportStackUsage was declared as `uint32_t`. This commit changes the type of local stack variable in `prvReportStackUsage` to `TraceUnsignedBaseType_t` to match the function parameter type.