### PR TITLE
Fix out-of-bounds access in TRACE_GET_TRACE_CLASS_FROM_QUEUE_OBJECT

### DIFF
--- a/kernelports/FreeRTOS/include/trcKernelPort.h
+++ b/kernelports/FreeRTOS/include/trcKernelPort.h
@@ -881,7 +881,7 @@ const char* pszTraceGetErrorNotEnoughHandles(traceObjectClass objectclass);
  */
 void* prvTraceGetCurrentTaskHandle(void);
 
-extern traceObjectClass TraceQueueClassTable[5];
+extern traceObjectClass TraceQueueClassTable[6];
 
 
 /*** Event codes for snapshot mode - must match Tracealyzer config files ******/

--- a/kernelports/FreeRTOS/trcKernelPort.c
+++ b/kernelports/FreeRTOS/trcKernelPort.c
@@ -444,12 +444,13 @@ int uiInEventGroupSetBitsFromISR = 0;
 /**
  * @internal Class reference table
  */
-traceObjectClass TraceQueueClassTable[5] = {
+traceObjectClass TraceQueueClassTable[6] = {
 	TRACE_CLASS_QUEUE,
 	TRACE_CLASS_MUTEX,
 	TRACE_CLASS_SEMAPHORE,
 	TRACE_CLASS_SEMAPHORE,
-	TRACE_CLASS_MUTEX
+	TRACE_CLASS_MUTEX,
+	TRACE_CLASS_QUEUE
 };
 
 #if (TRC_CFG_SCHEDULING_ONLY == 0)


### PR DESCRIPTION
Description
------------

`TRACE_GET_TRACE_CLASS_FROM_QUEUE_OBJECT` is implemented like the following:

```c
#define TRACE_GET_TRACE_CLASS_FROM_QUEUE_CLASS(kernelClass) TraceQueueClassTable[kernelClass]
#define TRACE_GET_TRACE_CLASS_FROM_QUEUE_OBJECT(pxObject) TRACE_GET_TRACE_CLASS_FROM_QUEUE_CLASS(prvTraceGetQueueType(pxObject))
```

`TraceQueueClassTable` only contains 5 entries but `prvTraceGetQueueType` can return 6 possible values:
```c
traceObjectClass TraceQueueClassTable[5] = {
	TRACE_CLASS_QUEUE,
	TRACE_CLASS_MUTEX,
	TRACE_CLASS_SEMAPHORE,
	TRACE_CLASS_SEMAPHORE,
	TRACE_CLASS_MUTEX
};

/* Possible values returned by prvTraceGetQueueType. */
#define queueQUEUE_TYPE_BASE                  ( ( uint8_t ) 0U )
#define queueQUEUE_TYPE_MUTEX                 ( ( uint8_t ) 1U )
#define queueQUEUE_TYPE_COUNTING_SEMAPHORE    ( ( uint8_t ) 2U )
#define queueQUEUE_TYPE_BINARY_SEMAPHORE      ( ( uint8_t ) 3U )
#define queueQUEUE_TYPE_RECURSIVE_MUTEX       ( ( uint8_t ) 4U )
#define queueQUEUE_TYPE_SET                   ( ( uint8_t ) 5U )
```

This results in out-of-bounds access when trying to deduce trace class for Queue Sets.

This PR addresses the issue by adding one extra entry in the TraceQueueClassTable for queue sets.

Test Steps
-----------
Run with address-sanitizer.

Before -
```
==676932==ERROR: AddressSanitizer: global-buffer-overflow on address 0x5690a0e28b45 at pc 0x5690a0d76193 bp 0x7ffdd6aa8850 sp 0x7ffdd6aa8840
READ of size 1 at 0x5690a0e28b45 thread T0
    #0 0x5690a0d76192 in prvInitialiseNewQueue /home/ubuntu/workplace/contrib/FreeRTOS/FreeRTOS/Source/queue.c:608
    #1 0x5690a0d7f371 in xQueueGenericCreate /home/ubuntu/workplace/contrib/FreeRTOS/FreeRTOS/Source/queue.c:544
    #2 0x5690a0d7f371 in xQueueCreateSet /home/ubuntu/workplace/contrib/FreeRTOS/FreeRTOS/Source/queue.c:3182
    #3 0x5690a0dadd89 in vStartQueueSetPollingTask /home/ubuntu/workplace/contrib/FreeRTOS/FreeRTOS/Demo/Common/Minimal/QueueSetPolling.c:91
    #4 0x5690a0d71fac in main_full /home/ubuntu/workplace/contrib/FreeRTOS/FreeRTOS/Demo/Posix_GCC/main_full.c:232
    #5 0x5690a0d6efc6 in main /home/ubuntu/workplace/contrib/FreeRTOS/FreeRTOS/Demo/Posix_GCC/main.c:179
    #6 0x76a214029d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #7 0x76a214029e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #8 0x5690a0d6faa4 in _start (/home/ubuntu/workplace/contrib/FreeRTOS/FreeRTOS/Demo/Posix_GCC/build/posix_demo+0x63aa4)

0x5690a0e28b45 is located 0 bytes to the right of global variable 'TraceQueueClassTable' defined in '/home/ubuntu/workplace/contrib/FreeRTOS/FreeRTOS-Plus/Source/FreeRTOS-Plus-Trace/kernelports/FreeRTOS/trcKernelPort.c:447:18' (0x5690a0e28b40) of size 5
0x5690a0e28b45 is located 59 bytes to the left of global variable '*.Lubsan_data38' defined in '/home/ubuntu/workplace/contrib/FreeRTOS/FreeRTOS-Plus/Source/FreeRTOS-Plus-Trace/kernelports/FreeRTOS/trcKernelPort.c' (0x5690a0e28b80) of size 32
```
After -
```
No error.
```
